### PR TITLE
Create types.d.ts

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,62 @@
+declare module 'regexparam'
+
+/**
+ * Data to define route
+ */
+declare interface RouteDefineData {
+    path: string
+    component?: RouteComponent
+    components?: { [key: string]: RouteComponent }
+    name?: string
+    meta?: any
+    beforeEnter?: RouterHook
+    children?: RouteDefineData
+}
+
+/**
+ * Parsed route data
+ */
+declare interface RouteMatchData extends RouteDefineData {
+    nestingDepth: number
+    id: string
+    parentId: string
+    regexpPath: RegExp
+    pathKeys: string[]
+}
+
+/**
+ * Data to send into currentRoute and hooks
+ */
+declare interface RouteInfoData {
+    fullPath: string
+    params: { [key: string]: string }
+    query: ParsedQueryObject
+    name?: string
+    meta?: string
+}
+
+/**
+ * Misc declarations
+ */
+
+declare type RouteComponent = any
+
+declare type NextCallback = (arg?: boolean | string) => void
+
+declare type ParsedQueryObject = {
+    [key: string]: string | string[] | null
+}
+
+declare type RouterMode = 'hash' | 'history' | 'silent'
+
+declare type RouterSettings = {
+    mode: RouterMode
+    routes: RouteDefineData[]
+    base?: string
+}
+
+declare type RouterHook = (to: RouteInfo, from: RouteInfo | null, next?: NextCallback) => void | Promise<void>
+
+declare type HookCommand = boolean | string
+
+declare type ObservableListener<T> = (value: T) => void


### PR DESCRIPTION
Copied the file from the core lib, at https://github.com/easyroute-router/easyroute-core/blob/master/types.d.ts

Although, it would seem most correct to have **svelte-easyroute** re-expose the definitions from **easyroute-core**, so that we don't have 2 different definitions for the same functions. I'm new to creating NPM modules, and don't know how best to achieve that; happy to learn and edit as necessary :)