### PR TITLE
v3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 * fix: `currentRoute` empty on startup (#26);
 * `currentRoute` prop is deprecated and will be removed in 3.1.0;
 
-
 ### v3.0.4
 * `easyroute-core` updated to 1.3.3 ([changelog](https://github.com/easyroute-router/easyroute-core/blob/master/CHANGELOG.md#v133)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v3.0.5
+* fix: `currentRoute` empty on startup (#26);
+* `currentRoute` prop is deprecated and will be removed in 3.1.0;
+
+
 ### v3.0.4
 * `easyroute-core` updated to 1.3.3 ([changelog](https://github.com/easyroute-router/easyroute-core/blob/master/CHANGELOG.md#v133)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### v3.0.5
 * fix: `currentRoute` empty on startup (#26);
+* fix: outlet auto-restore after visiting unknown route (#27);
 * `currentRoute` prop is deprecated and will be removed in 3.1.0;
+* demo-app fix: active menu buttons highlighted.
 
 ### v3.0.4
 * `easyroute-core` updated to 1.3.3 ([changelog](https://github.com/easyroute-router/easyroute-core/blob/master/CHANGELOG.md#v133)).

--- a/demo-app/src/Components/MainMenu.svelte
+++ b/demo-app/src/Components/MainMenu.svelte
@@ -38,7 +38,7 @@
         {:else if item.title === 'divider'}
             <li class="uk-nav-divider"></li>
         {:else}
-            <li class:uk-active={ routePath === item.url }>
+            <li class:uk-active={ routePath.includes(item.url) }>
                 {#if item.url.includes('http')}
                     <a href="{item.url}" target="_blank">
                         {@html item.title}

--- a/demo-app/src/texts/en/current-route-info.md
+++ b/demo-app/src/texts/en/current-route-info.md
@@ -2,7 +2,33 @@
 From every child component you can access current 
 route state. There are two ways to do this:
 
-### 1. Export variable in outlet's child component
+### 1. useCurrentRoute hook
+In any component wrapped with `<EasyrouteProvider>`,
+on any level of nesting, you can use `useCurrentRoute`
+hook. It is a custom implementation of Observable
+pattern, so you can "subscribe" to current route
+object. It goes like this:
+
+```html
+<script>
+    // Component.svelte
+
+    import { useCurrentRoute } from "svelte-easyroute"
+    import { onDestroy } from "svelte"
+    
+    const unsubscribe = useCurrentRoute((currentRoute) => {
+        console.log(currentRoute)
+    })
+    
+    onDestroy(unsubscribe)
+</script>
+```
+**Don't forget** to `unsibscribe` when leaving your component!
+If you will not, it can cause memory leak.
+
+### 2. Export variable in outlet's child component
+> **Warning!** This is a deprecated method and will be removed in version 3.1.0. 
+> I recommend that you use the useCurrentRoute hook as it is more reliable and available within the entire application.
 
 If your component is direct child of `<RouterOutlet>`,
 ust put in the <script> tag:
@@ -27,28 +53,4 @@ That's it!
   }
 }
 ```
-
-### 2. useCurrentRoute hook
-In any component wrapped with `<EasyrouteProvider>`, 
-on any level of nesting, you can use `useCurrentRoute`
-hook. It is a custom implementation of Observable
-pattern, so you can "subscribe" to current route
-object. It goes like this:
-
-```html
-<script>
-    // Component.svelte
-
-    import { useCurrentRoute } from "svelte-easyroute"
-    import { onDestroy } from "svelte"
-    
-    const unsubscribe = useCurrentRoute((currentRoute) => {
-        console.log(currentRoute)
-    })
-    
-    onDestroy(unsubscribe)
-</script>
-```
-**Don't forget** to `unsibscribe` when leaving your component!
-If you will not, it can cause memory leak.
 

--- a/demo-app/src/texts/ru/current-route-info.md
+++ b/demo-app/src/texts/ru/current-route-info.md
@@ -2,7 +2,33 @@
 Из каждого дочернего для представления компонента вы 
 можете получить доступ к текущему маршруту. Есть два пути:
 
-### 1. Экспортируемая переменная 
+### 1. Хук useCurrentRoute
+В каждом компоненте, обёрнутом в `<EasyrouteProvider>`,
+на любом уровне вложенности, вы можете использовать хук
+`useCurrentRoute`. Это имплементация паттерна Observable, так
+что вы можете "подписаться" на объект текущего маршрута. Вот так:
+
+```html
+<script>
+    // Component.svelte
+
+    import { useCurrentRoute } from "svelte-easyroute"
+    import { onDestroy } from "svelte"
+    
+    const unsubscribe = useCurrentRoute((currentRoute) => {
+        console.log(currentRoute)
+    })
+    
+    onDestroy(unsubscribe)
+</script>
+```
+
+**Не забудьте** отписаться (`unsubscribe`), когда покидаете
+компонент! Если этого не сделать, возможны утечки памяти.
+
+### 2. Экспортируемая переменная 
+> **Внимание!** Это устаревший метод, и он будет удалён в версии 3.1.0. 
+> Рекомендую вам пользоваться хуком useCurrentRoute, как более надёжным, и доступным внутри всего приложения.
 
 Если ваш компонент прямой "ребёнок" `<RouterOutlet>`,
 просто поместите это в тег <script>:
@@ -27,28 +53,4 @@ export let currentRoute
   }
 }
 ```
-
-### 2. Хук useCurrentRoute
-В каждом компоненте, обёрнутом в `<EasyrouteProvider>`, 
-на любом уровне вложенности, вы можете использовать хук 
-`useCurrentRoute`. Это имплементация паттерна Observable, так
-что вы можете "подписаться" на объект текущего маршрута. Вот так:
-
-```html
-<script>
-    // Component.svelte
-
-    import { useCurrentRoute } from "svelte-easyroute"
-    import { onDestroy } from "svelte"
-    
-    const unsubscribe = useCurrentRoute((currentRoute) => {
-        console.log(currentRoute)
-    })
-    
-    onDestroy(unsubscribe)
-</script>
-```
-
-**Не забудьте** отписаться (`unsubscribe`), когда покидаете 
-компонент! Если этого не сделать, возможны утечки памяти.
 

--- a/lib/RouterOutlet.svelte
+++ b/lib/RouterOutlet.svelte
@@ -25,7 +25,7 @@
     let previousRutePath = null
     let unsubscribe = undefined
     let outletElement = null
-    let firstRouteResolved = false
+    let firstRouteResolved = SSR_CONTEXT
 
     if (!_router) {
         throw new Error('[Easyroute] RouterOutlet: no router instance found. Did you forget to wrap your ' +

--- a/lib/RouterOutlet.svelte
+++ b/lib/RouterOutlet.svelte
@@ -25,6 +25,7 @@
     let previousRutePath = null
     let unsubscribe = undefined
     let outletElement = null
+    let firstRouteResolved = false
 
     if (!_router) {
         throw new Error('[Easyroute] RouterOutlet: no router instance found. Did you forget to wrap your ' +
@@ -63,7 +64,11 @@
             else component = currentRoute.components ? currentRoute.components[name] : null
             changeComponent(component, currentRoute.id)
             await delay(transitionData ? transitionData.leavingDuration : 0)
-            routeData = _router.currentRoute
+            routeData = {
+                ..._router.currentRoute,
+                WARNING: 'Accessing the current route object via the "currentRoute" property is deprecated and will be removed in the next MINOR version. Use the "useCurrentRoute" hook instead (https://easyroute.lyoha.info/page/current-route-info)'
+            }
+            firstRouteResolved = true
         } else {
             currentComponent = null
         }
@@ -100,5 +105,7 @@
     class="easyroute-outlet{ passedClasses ? ` ${passedClasses}` : '' }{ transitionClassName ? ` ${transitionClassName}` : '' }"
     {...attrs}
 >
-    <svelte:component this={currentComponent} currentRoute={routeData} router={_router} outlet={outletElement} />
+    {#if firstRouteResolved}
+        <svelte:component this={currentComponent} currentRoute={routeData} router={_router} outlet={outletElement} />
+    {/if}
 </div>

--- a/lib/RouterOutlet.svelte
+++ b/lib/RouterOutlet.svelte
@@ -70,7 +70,8 @@
             }
             firstRouteResolved = true
         } else {
-            currentComponent = null
+            changeComponent(null, `${Date.now()}-nonexistent-route`)
+            console.warn('[Easyroute] Warning: route not found')
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-easyroute",
   "description": "Config-based router for Svelte in style of Vue Router with SSR support",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "main": "lib/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* fix: `currentRoute` empty on startup (#26);
* fix: outlet auto-restore after visiting unknown route (#27);
* `currentRoute` prop is deprecated and will be removed in 3.1.0;
* demo-app fix: active menu buttons highlighted.
